### PR TITLE
fix: correct wrong master release push name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,15 +59,12 @@ jobs:
         GOARCH: "${{ matrix.version.goarch }}"
         CGO_ENABLED: "0"
     - name: Rename release asset
-      run: |-
-        [[ -z "${{ github.head_ref }}" ]] && REF_ANNOTATION="${{ github.ref }}" || REF_ANNOTATION="${{ github.head_ref }}"
-        mv ghafs "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${REF_ANNOTATION}"
+      run: mv ghafs "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${{ github.head_ref }}"
     - name: Upload release asset
       run: |-
         REPO_OWNER="$(echo "${{ github.repository }}" | cut -d '/' -f1)"
         REPO_NAME="$(echo "${{ github.repository }}" | cut -d '/' -f2)"
-        [[ -z "${{ github.head_ref }}" ]] && REF_ANNOTATION="${{ github.ref }}" || REF_ANNOTATION="${{ github.head_ref }}"
         ghr -t ${{ secrets.GITHUB_TOKEN }} -u "${REPO_OWNER}" -r "${REPO_NAME}" \
           -c ${{ github.sha }} -replace experimental \
-          "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${REF_ANNOTATION}"
+          "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${{ github.head_ref }}"
       if: matrix.version.go == '1.13.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,15 @@ jobs:
         GOARCH: "${{ matrix.version.goarch }}"
         CGO_ENABLED: "0"
     - name: Rename release asset
-      run: mv ghafs "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${{ github.head_ref }}"
+      run: |-
+        [[ -z "${{ github.head_ref }}" ]] && REF_ANNOTATION="${{ github.ref }}" || REF_ANNOTATION="${{ github.head_ref }}"
+        mv ghafs "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${REF_ANNOTATION}"
     - name: Upload release asset
       run: |-
         REPO_OWNER="$(echo "${{ github.repository }}" | cut -d '/' -f1)"
         REPO_NAME="$(echo "${{ github.repository }}" | cut -d '/' -f2)"
+        [[ -z "${{ github.head_ref }}" ]] && REF_ANNOTATION="${{ github.ref }}" || REF_ANNOTATION="${{ github.head_ref }}"
         ghr -t ${{ secrets.GITHUB_TOKEN }} -u "${REPO_OWNER}" -r "${REPO_NAME}" \
           -c ${{ github.sha }} -replace experimental \
-          "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${{ github.head_ref }}"
+          "ghafs_${{ matrix.version.goos }}_${{ matrix.version.goarch }}_${REF_ANNOTATION}"
       if: matrix.version.go == '1.13.x'


### PR DESCRIPTION
Fix `push` event's ref annotation for the release binary in assets.