### PR TITLE
chore: split up into different files

### DIFF
--- a/ghafs.go
+++ b/ghafs.go
@@ -12,44 +12,21 @@ import (
 	"github.com/google/go-github/v28/github"
 )
 
-type ReleaseAssets struct {
-	release *github.RepositoryRelease
-	assets  []*github.ReleaseAsset
-}
-
-type ReleaseAssetsMap map[string]ReleaseAssets
-
-func rasToDirents(rasm *ReleaseAssetsMap) []fuse.Dirent {
-	dirents := make([]fuse.Dirent, len(*rasm))
-
-	i := 0
-	for tag, ras := range *rasm {
-		dirents[i] = fuse.Dirent{
-			Inode: uint64(ras.release.GetID()),
-			Name:  tag,
-			Type:  fuse.DT_Dir,
-		}
-		i++
-	}
-	return dirents
-}
-
-func assetsToDirents(assets []*github.ReleaseAsset) []fuse.Dirent {
-	dirents := make([]fuse.Dirent, len(assets))
-
-	for i, asset := range assets {
-		dirents[i] = fuse.Dirent{
-			Inode: uint64(asset.GetID()),
-			Name:  asset.GetName(),
-			Type:  fuse.DT_File,
-		}
-	}
-	return dirents
-}
-
 // ghaFS implements the GitHub Release Assets file system.
 type ghaFS struct {
 	rasm  *ReleaseAssetsMap
+	token *string
+}
+
+// root implements both Node and Handle for the root directory.
+type root struct {
+	rasm  *ReleaseAssetsMap
+	token *string
+}
+
+// tagDir implements both Node and Handle for the root directory.
+type tagDir struct {
+	ras   *ReleaseAssets
 	token *string
 }
 
@@ -61,16 +38,14 @@ func (g ghaFS) Root() (fs.Node, error) {
 	return root{rasm: g.rasm, token: g.token}, nil
 }
 
-// root implements both Node and Handle for the root directory.
-type root struct {
-	rasm  *ReleaseAssetsMap
-	token *string
-}
-
 func (root) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = 1
 	a.Mode = os.ModeDir | 0555
 	return nil
+}
+
+func (r root) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
+	return rasToDirents(r.rasm), nil
 }
 
 func (r root) Lookup(ctx context.Context, name string) (fs.Node, error) {
@@ -83,20 +58,14 @@ func (r root) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	return nil, fuse.ENOENT
 }
 
-func (r root) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
-	return rasToDirents(r.rasm), nil
-}
-
-// tagDir implements both Node and Handle for the root directory.
-type tagDir struct {
-	ras   *ReleaseAssets
-	token *string
-}
-
 func (t tagDir) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = uint64(t.ras.release.GetID())
 	a.Mode = os.ModeDir | 0555
 	return nil
+}
+
+func (t tagDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
+	return assetsToDirents(t.ras.assets), nil
 }
 
 func (t tagDir) Lookup(ctx context.Context, name string) (fs.Node, error) {
@@ -106,10 +75,6 @@ func (t tagDir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 		}
 	}
 	return nil, fuse.ENOENT
-}
-
-func (t tagDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
-	return assetsToDirents(t.ras.assets), nil
 }
 
 // assetFile implements both Node and Handle for the hello file.

--- a/ghafsMapping.go
+++ b/ghafsMapping.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bazil.org/fuse"
+	"github.com/google/go-github/v28/github"
+)
+
+func rasToDirents(rasm *ReleaseAssetsMap) []fuse.Dirent {
+	dirents := make([]fuse.Dirent, len(*rasm))
+
+	i := 0
+	for tag, ras := range *rasm {
+		dirents[i] = fuse.Dirent{
+			Inode: uint64(ras.release.GetID()),
+			Name:  tag,
+			Type:  fuse.DT_Dir,
+		}
+		i++
+	}
+	return dirents
+}
+
+func assetsToDirents(assets []*github.ReleaseAsset) []fuse.Dirent {
+	dirents := make([]fuse.Dirent, len(assets))
+
+	for i, asset := range assets {
+		dirents[i] = fuse.Dirent{
+			Inode: uint64(asset.GetID()),
+			Name:  asset.GetName(),
+			Type:  fuse.DT_File,
+		}
+	}
+	return dirents
+}

--- a/main.go
+++ b/main.go
@@ -45,25 +45,10 @@ func main() {
 	}
 
 	client := github.NewClient(tc)
-	releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, nil)
+	rasm, err := getReleaseAssets(ctx, client, owner, repo)
 
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	rasm := make(ReleaseAssetsMap)
-
-	for _, release := range releases {
-		assets, _, err := client.Repositories.ListReleaseAssets(ctx, owner, repo, release.GetID(), nil)
-
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		rasm[release.GetTagName()] = ReleaseAssets{
-			release,
-			assets,
-		}
 	}
 
 	// FUSE Set-up
@@ -87,7 +72,7 @@ func main() {
 		token = &oauth2Token
 	}
 
-	err = fs.Serve(c, NewGhaFS(&rasm, token))
+	err = fs.Serve(c, NewGhaFS(rasm, token))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/releaseAssets.go
+++ b/releaseAssets.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+
+	"github.com/google/go-github/v28/github"
+)
+
+type ReleaseAssets struct {
+	release *github.RepositoryRelease
+	assets  []*github.ReleaseAsset
+}
+
+type ReleaseAssetsMap map[string]ReleaseAssets
+
+func getReleaseAssets(ctx context.Context, client *github.Client, owner string, repo string) (*ReleaseAssetsMap, error) {
+	rasm := make(ReleaseAssetsMap)
+
+	releases, _, err := client.Repositories.ListReleases(ctx, owner, repo, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, release := range releases {
+		assets, _, err := client.Repositories.ListReleaseAssets(ctx, owner, repo, release.GetID(), nil)
+
+		if err != nil {
+			return nil, err
+		}
+
+		rasm[release.GetTagName()] = ReleaseAssets{
+			release,
+			assets,
+		}
+	}
+
+	return &rasm, nil
+}


### PR DESCRIPTION
`ghafs.go` now focuses solely on implementing the interface to make up
the filesystem.