### PR TITLE
feat: refresh assets when listing root level dirs

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	client := github.NewClient(tc)
-	rasm, err := getReleaseAssets(ctx, client, owner, repo)
+	mgmt, err := makeReleaseAssetsMgmt(ctx, client, owner, repo)
 
 	if err != nil {
 		log.Fatal(err)
@@ -72,7 +72,7 @@ func main() {
 		token = &oauth2Token
 	}
 
-	err = fs.Serve(c, NewGhaFS(rasm, token))
+	err = fs.Serve(c, NewGhaFS(mgmt, token))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/releaseAssets.go
+++ b/releaseAssets.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"sync"
 
 	"github.com/google/go-github/v28/github"
 )
@@ -36,4 +37,45 @@ func getReleaseAssets(ctx context.Context, client *github.Client, owner string, 
 	}
 
 	return &rasm, nil
+}
+
+type ReleaseAssetsMgmt struct {
+	ctx    context.Context
+	client *github.Client
+	owner  string
+	repo   string
+
+	current *ReleaseAssetsMap
+	m       sync.Mutex
+}
+
+func makeReleaseAssetsMgmt(ctx context.Context, client *github.Client, owner string, repo string) (*ReleaseAssetsMgmt, error) {
+	var mgmt ReleaseAssetsMgmt
+	mgmt.ctx = ctx
+	mgmt.client = client
+	mgmt.owner = owner
+	mgmt.repo = repo
+
+	_, err := mgmt.refresh()
+	return &mgmt, err
+}
+
+func (mgmt *ReleaseAssetsMgmt) refresh() (*ReleaseAssetsMap, error) {
+	mgmt.m.Lock()
+	defer mgmt.m.Unlock()
+
+	var err error
+	mgmt.current, err = getReleaseAssets(mgmt.ctx, mgmt.client, mgmt.owner, mgmt.repo)
+
+	// See getCurrent for comments about correctness
+	return mgmt.current, err
+}
+
+func (mgmt *ReleaseAssetsMgmt) getCurrent() *ReleaseAssetsMap {
+	// For simplicity, we assume readonly access to ReleaseAssetsMgmt
+	// so that we do not need to lock and return a cloned ReleaseAssetsMap
+	// for correctness
+	mgmt.m.Lock()
+	defer mgmt.m.Unlock()
+	return mgmt.current
 }


### PR DESCRIPTION
This can be expensive and eats into rate limit, but makes it more
useful overall for a running service.