### PR TITLE
feat(flag): allow allow-other with go-arg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
+	github.com/alexflint/go-arg v1.3.0
 	github.com/google/go-github/v28 v28.1.1
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,13 @@
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669 h1:FNCRpXiquG1aoyqcIWVFmpTSKVcx2bQD38uZZeGtdlw=
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/alexflint/go-arg v1.3.0 h1:UfldqSdFWeLtoOuVRosqofU4nmhI1pYEbT4ZFS34Bdo=
+github.com/alexflint/go-arg v1.3.0/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
+github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
+github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -8,6 +15,8 @@ github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBE
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/main.go
+++ b/main.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -14,50 +12,55 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s <mountpoint> <owner> <repo> [access-token]\n", os.Args[0])
-	flag.PrintDefaults()
+type args struct {
+	Mountpoint  string `arg:"positional,required"`
+	Owner       string `arg:"positional,required"`
+	Repo        string `arg:"positional,required"`
+	AccessToken string `arg:"--token" help:"GitHub access token for authorization"`
+	AllowOther  bool   `arg:"--allow-other" help:"Use FUSE allow_other mode (allow_root doesn't work, so not available)"`
+}
+
+func (args) Description() string {
+	return "GitHub Release Assets FUSE CLI"
 }
 
 func main() {
-	flag.Usage = usage
-	flag.Parse()
-
-	if flag.NArg() < 3 || flag.NArg() > 4 {
-		usage()
-		os.Exit(1)
-	}
-
-	mountpoint := flag.Arg(0)
-	owner := flag.Arg(1)
-	repo := flag.Arg(2)
-	oauth2Token := flag.Arg(3)
+	var args args
 
 	// GitHub Set-up
 	ctx := context.Background()
 
 	var tc *http.Client
-	if oauth2Token != "" {
+	if args.AccessToken != "" {
 		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: oauth2Token},
+			&oauth2.Token{AccessToken: args.AccessToken},
 		)
 		tc = oauth2.NewClient(ctx, ts)
 	}
 
 	client := github.NewClient(tc)
-	mgmt, err := makeReleaseAssetsMgmt(ctx, client, owner, repo)
+	mgmt, err := makeReleaseAssetsMgmt(ctx, client, args.Owner, args.Repo)
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// FUSE Set-up
-	c, err := fuse.Mount(
-		mountpoint,
+	mountOptions := []fuse.MountOption{
 		fuse.FSName("ghafs"),
 		fuse.Subtype("ghafs"),
 		fuse.LocalVolume(),
-		fuse.VolumeName(fmt.Sprintf("GitHub Release Assets Filesystem for %s/%s", owner, repo)),
+		fuse.VolumeName(fmt.Sprintf("GitHub Release Assets Filesystem for %s/%s", args.Owner, args.Repo)),
+		fuse.ReadOnly(),
+	}
+
+	if args.AllowOther {
+		mountOptions = append(mountOptions, fuse.AllowOther())
+	}
+
+	// FUSE Set-up
+	c, err := fuse.Mount(
+		args.Mountpoint,
+		mountOptions...,
 	)
 
 	if err != nil {
@@ -67,12 +70,7 @@ func main() {
 	defer c.Close()
 
 	// Prepare to pass around the token via reference
-	var token *string
-	if oauth2Token != "" {
-		token = &oauth2Token
-	}
-
-	err = fs.Serve(c, NewGhaFS(mgmt, token))
+	err = fs.Serve(c, NewGhaFS(mgmt, &args.AccessToken))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Optionally accepts `--allow-other` flag so that the mount is visible to
other user other than the user.

Use a declarative struct via `go-arg` to describe all the flags.