### PR TITLE
fix(pagination): loop to get all releases and assets

### DIFF
--- a/ghafs.go
+++ b/ghafs.go
@@ -93,7 +93,7 @@ func (t tagDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 }
 
 func (t tagDir) Lookup(ctx context.Context, name string) (fs.Node, error) {
-	assets, err := t.assets.refresh()
+	assets, err := t.assets.get()
 
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func (args) Description() string {
 }
 
 func (args) Version() string {
-	return "ghafs 0.1.0"
+	return "ghafs 0.1.1"
 }
 
 func main() {


### PR DESCRIPTION
Update to 0.1.1 for patch fix.

Previously did not consider pagination at all, so a max of 30 can only
be returned.

Fix assets fetching bug where previously it keeps refreshing rather than
calling "if cached get from cached state instead".

Add last-updated to greatly help preventing the FS API from happy
triggering GitHub HTTP queries.