### PR TITLE
fix(refresh): force assets to refresh via Lookup

### DIFF
--- a/ghafs.go
+++ b/ghafs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -61,7 +62,7 @@ func (r root) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 }
 
 func (r root) Lookup(ctx context.Context, name string) (fs.Node, error) {
-	releases, err := r.mgmt.releases.get()
+	releases, err := r.mgmt.releases.refresh()
 
 	if err != nil {
 		return nil, err
@@ -93,7 +94,7 @@ func (t tagDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 }
 
 func (t tagDir) Lookup(ctx context.Context, name string) (fs.Node, error) {
-	assets, err := t.assets.get()
+	assets, err := t.assets.refresh()
 
 	if err != nil {
 		return nil, err
@@ -126,6 +127,10 @@ func (f assetFile) ReadAll(ctx context.Context) ([]byte, error) {
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Status Code: %v, message: %v", resp.StatusCode, resp.Status)
 	}
 
 	log.Printf("Asset URL: %v, Content-Length: %v", f.asset.GetURL(), resp.ContentLength)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/alexflint/go-arg"
 
@@ -15,11 +16,12 @@ import (
 )
 
 type args struct {
-	Mountpoint  string `arg:"positional,required"`
-	Owner       string `arg:"positional,required"`
-	Repo        string `arg:"positional,required"`
-	AccessToken string `arg:"--token" help:"GitHub access token for authorization"`
-	AllowOther  bool   `arg:"--allow-other" help:"use FUSE allow_other mode (allow_root doesn't work, so not available)"`
+	Mountpoint       string `arg:"positional,required"`
+	Owner            string `arg:"positional,required"`
+	Repo             string `arg:"positional,required"`
+	AccessToken      string `arg:"--token" help:"GitHub access token for authorization"`
+	AllowOther       bool   `arg:"--allow-other" help:"use FUSE allow_other mode (allow_root doesn't work, so not available)"`
+	RefreshThreshold uint32 `arg:"--refresh" default:"30" help:"number of seconds that must elapsed before subsequent assets refresh can occur"`
 }
 
 func (args) Description() string {
@@ -27,7 +29,7 @@ func (args) Description() string {
 }
 
 func (args) Version() string {
-	return "ghafs 0.1.1"
+	return "ghafs 0.1.2"
 }
 
 func main() {
@@ -46,7 +48,7 @@ func main() {
 	}
 
 	client := github.NewClient(tc)
-	mgmt := makeReleaseMgmt(makeGhContext(ctx, client, args.Owner, args.Repo))
+	mgmt := makeReleaseMgmt(makeGhContext(ctx, client, args.Owner, args.Repo, time.Duration(args.RefreshThreshold)*time.Second))
 
 	mountOptions := []fuse.MountOption{
 		fuse.FSName("ghafs"),


### PR DESCRIPTION
Previously it was entirely possible for `ReadAll` to be repeatedly
invoked without refreshing the assets, since `Lookup` only `.get`
instead of `.refresh()`.

Since there is a refresh threshold now, it is better to do a refresh
if the threshold has exceeded, to prevent issues with asset of similar
name being deleted and re-added, or if the asset is removed all
together, which can be detected at the filesystem level instead.

Also fix when status code is non-200 to return as error instead.

Allow the refresh threshold to be specified as arg, though it defaults
to the current 30 seconds.