### PR TITLE
feat(timestamps): add to dir and file meta

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func (args) Description() string {
 }
 
 func (args) Version() string {
-	return "ghafs 0.1.2"
+	return "ghafs 0.1.3"
 }
 
 func main() {
@@ -48,7 +48,11 @@ func main() {
 	}
 
 	client := github.NewClient(tc)
-	mgmt := makeReleaseMgmt(makeGhContext(ctx, client, args.Owner, args.Repo, time.Duration(args.RefreshThreshold)*time.Second))
+	mgmt, err := makeReleaseMgmt(makeGhContext(ctx, client, args.Owner, args.Repo, time.Duration(args.RefreshThreshold)*time.Second))
+
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	mountOptions := []fuse.MountOption{
 		fuse.FSName("ghafs"),

--- a/releaseAssets.go
+++ b/releaseAssets.go
@@ -25,6 +25,7 @@ type GhContext struct {
 // assets content with the given GitHub context
 type ReleaseMgmt struct {
 	ghc      *GhContext
+	repo     *github.Repository
 	releases *ReleasesWrap
 }
 
@@ -60,8 +61,14 @@ func makeGhContext(ctx context.Context, client *github.Client, owner string, rep
 	return &GhContext{ctx, client, owner, repo, refreshThreshold}
 }
 
-func makeReleaseMgmt(ghc *GhContext) *ReleaseMgmt {
-	return &ReleaseMgmt{ghc, makeReleasesWrap(ghc)}
+func makeReleaseMgmt(ghc *GhContext) (*ReleaseMgmt, error) {
+	repo, _, err := ghc.client.Repositories.Get(ghc.ctx, ghc.owner, ghc.repo)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReleaseMgmt{ghc, repo, makeReleasesWrap(ghc)}, nil
 }
 
 func makeReleasesWrap(ghc *GhContext) *ReleasesWrap {


### PR DESCRIPTION
The mapping is not exact and is to the best possible match.

- For the mounted root dir, it uses the GitHub repo updated time
- For release dirs, it uses the GitHub release published time
- For release asset files, it uses asset updated time

Bump version to 0.1.3 for release.